### PR TITLE
Use POST requests for Tavily search to avoid 405 errors

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,4 @@ pydantic
 lxml[html_clean]
 lxml_html_clean
 # sqlite3 is part of the Python standard library and does not need to be installed via pip.
-# Use the latest Tavily client – it performs POST requests internally.
-tavily-python>=0.5.0
 

--- a/backend/scraper.py
+++ b/backend/scraper.py
@@ -1,34 +1,66 @@
-import httpx
-from bs4 import BeautifulSoup
-from newspaper import Article as NewsArticle
-import sqlite3
-import random
-import json
+"""Utilities for collecting and rating feel‑good news articles.
+
+The module caches processed URLs in a small SQLite database to avoid
+duplicating work.  Articles are fetched and scored before being returned to
+the caller.
+
+The previous implementation called the Tavily API directly using an HTTP GET
+request which is no longer supported by the service.  Tavily now expects
+requests to be made with a POST request containing a small JSON payload.
+Attempting to hit the old endpoint resulted in ``405 Method Not Allowed``
+responses.  The code below performs the POST request manually via ``httpx`` and
+reads the API key from ``TAVILY_API_KEY`` so that searches work again.
+"""
+
+from __future__ import annotations
+
 import logging
+import os
+import sqlite3
 from typing import List, Tuple
-from tavily import TavilyClient
+
+import httpx
+from newspaper import Article as NewsArticle
+
+# ---------------------------------------------------------------------------
+# Configuration & logging
+# ---------------------------------------------------------------------------
 
 DB_PATH = "cache.db"
-
-# -----------------------------------------------
-# Logging for the scraper – we reuse the same logger hierarchy as the app.
-# -----------------------------------------------
 logger = logging.getLogger("backend.scraper")
 
-def init_db():
+_tavily_api_key = os.getenv(
+    "TAVILY_API_KEY", "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"
+)
+_tavily_headers = {"Content-Type": "application/json", "X-API-Key": _tavily_api_key}
+
+
+# ---------------------------------------------------------------------------
+# SQLite helpers
+# ---------------------------------------------------------------------------
+
+
+def init_db() -> None:
+    """Initialise the SQLite database used for caching processed URLs."""
+
     logger.info("Initializing SQLite cache database at %s", DB_PATH)
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
     cur.execute(
-        """CREATE TABLE IF NOT EXISTS watched (
-                    url TEXT PRIMARY KEY,
-                    watched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )"""
+        """
+        CREATE TABLE IF NOT EXISTS watched (
+            url TEXT PRIMARY KEY,
+            watched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
     )
     conn.commit()
     conn.close()
 
+
 def is_watched(url: str) -> bool:
+    """Return ``True`` if ``url`` has already been processed."""
+
     logger.debug("Checking if URL has been watched: %s", url)
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
@@ -37,7 +69,10 @@ def is_watched(url: str) -> bool:
     conn.close()
     return found
 
-def mark_watched(url: str):
+
+def mark_watched(url: str) -> None:
+    """Persist ``url`` in the cache so we do not process it again."""
+
     logger.info("Marking URL as watched: %s", url)
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
@@ -45,28 +80,48 @@ def mark_watched(url: str):
     conn.commit()
     conn.close()
 
-# --------------------------------------------------------------------
-# Tavily search helper – uses the official ``tavily-python`` client library
-# --------------------------------------------------------------------
-_tavily_client = TavilyClient("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")
 
---- a/catbreak/backend/scraper.py
-+++ b/catbreak/backend/scraper.py
-@@
--import httpx
-+import httpx
- import json
-+import os
-@@
--_tavily_client = TavilyClient("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")
-+_tavily_api_key = os.getenv("TAVILY_API_KEY", "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")
-+_tavily_client = TavilyClient(api_key=_tavily_api_key)
-+logger.info("Using Tavily client instance: %s", type(_tavily_client).__name__)
+# ---------------------------------------------------------------------------
+# Tavily search helper
+# ---------------------------------------------------------------------------
+
+
+def tavily_search(query: str, max_results: int = 30) -> List[str]:
+    """Search Tavily for ``query`` and return a list of result URLs."""
+
+    logger.info(
+        "Performing Tavily search for query: %s (max %d results)", query, max_results
+    )
+    payload = {"query": query, "max_results": max_results}
+    try:
+        resp = httpx.post(
+            "https://api.tavily.com/search",
+            json=payload,
+            headers=_tavily_headers,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        urls = [r["url"] for r in resp.json().get("results", [])]
+        logger.debug("Tavily returned %d URLs", len(urls))
+        return urls
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+        logger.error("Tavily API error: %s", exc)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Unexpected error while querying Tavily")
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Article fetching & rating
+# ---------------------------------------------------------------------------
+
 
 def fetch_article(url: str) -> Tuple[str, str]:
-    """Download and parse an article via ``newspaper3k``.
+    """Download and parse an article using ``newspaper3k``.
+
     Returns a tuple ``(title, summary)``.
     """
+
     logger.info("Fetching article from URL: %s", url)
     article = NewsArticle(url)
     article.download()
@@ -75,10 +130,14 @@ def fetch_article(url: str) -> Tuple[str, str]:
     logger.debug("Fetched article – title: %s", article.title[:60])
     return article.title, article.summary
 
+
 def rate_article(content: str) -> int:
     """Very naive "feel‑good" scorer.
-    Positive words add points, negative words subtract. Result is clamped to 1‑10.
+
+    Positive words add points, negative words subtract.
+    Result is clamped to the range 1‑10.
     """
+
     positives = [
         "help",
         "kind",
@@ -91,21 +150,20 @@ def rate_article(content: str) -> int:
         "cure",
         "breakthrough",
     ]
+
     negatives = ["war", "crime", "death", "disaster", "crisis", "fail", "tragedy"]
     content_lc = content.lower()
-    score = sum(word in content_lc for word in positives) - sum(word in content_lc for word in negatives)
+    score = sum(word in content_lc for word in positives) - sum(
+        word in content_lc for word in negatives
+    )
     rating = max(1, min(10, score + 5))
     logger.debug("Rating article – score: %d, final rating: %d", score, rating)
     return rating
 
+
 def get_few_good_articles() -> List[dict]:
-    """Entry point used by the API – returns up to 5 feel‑good articles with rating.
-    The function:
-    1. Ensures the DB exists.
-    2. Searches DuckDuckGo.
-    3. Walks the URLs, skipping any already‑watched.
-    4. Fetches, rates and stores each article.
-    """
+    """Return up to five feel‑good articles with basic metadata."""
+
     logger.info("Fetching a fresh batch of feel‑good articles")
     init_db()
     query = "feel good news positive uplifting recent"
@@ -119,10 +177,12 @@ def get_few_good_articles() -> List[dict]:
         try:
             title, summary = fetch_article(url)
             rating = rate_article(summary)
-            articles.append({"title": title, "summary": summary, "url": url, "rating": rating})
+            articles.append(
+                {"title": title, "summary": summary, "url": url, "rating": rating}
+            )
             mark_watched(url)
             logger.info("Collected article %d – %s", len(articles), title[:60])
-        except Exception as exc:  # pragma: no cover – individual article failures are expected
+        except Exception:  # pragma: no cover – individual failures are expected
             logger.exception("Failed to process URL %s", url)
             continue
         if len(articles) >= 5:
@@ -135,4 +195,15 @@ def get_few_good_articles() -> List[dict]:
         # In a real project you might fallback to cached data here.
 
     return articles
+
+
+__all__ = [
+    "fetch_article",
+    "get_few_good_articles",
+    "init_db",
+    "is_watched",
+    "mark_watched",
+    "rate_article",
+    "tavily_search",
+]
 


### PR DESCRIPTION
## Summary
- send Tavily search requests via `httpx.post` with API key header
- drop unused `tavily-python` dependency

## Testing
- `python -m py_compile backend/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4adbfd1d8832a8323067d92b45819