### PR TITLE
Use curl POST for Tavily search

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,4 @@ pydantic
 lxml[html_clean]
 lxml_html_clean
 # sqlite3 is part of the Python standard library and does not need to be installed via pip.
-# Use the latest Tavily client – it performs POST requests internally.
-tavily-python>=0.5.0
 


### PR DESCRIPTION
## Summary
- replace httpx Tavily query with `curl` POST using Bearer auth
- document the `curl` approach after 405 errors from previous GET requests

## Testing
- `python -m py_compile backend/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4adbfd1d8832a8323067d92b45819